### PR TITLE
매수/매도 주문 화면 및 호가창 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.5",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "recharts": "^2.13.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/src/pages/property_detail/trade/TradeBoard.jsx
+++ b/src/pages/property_detail/trade/TradeBoard.jsx
@@ -1,10 +1,46 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Tab, Tabs } from 'react-bootstrap';
 import TradeOptionsBox from './TradeOptionsBox';
 import TradeOrderForm from './TradeOrderForm';
+import axios from 'axios';
+import { useTradeContext } from './TradeContext';
 
 export default function TradeBoard() {
-  const [key, setKey] = useState('buy');
+  const { id: propertyId } = useTradeContext(); // 건물Id를 Context에서 가져옴
+  const [key, setKey] = useState('buy'); // 현재 활성화된 탭
+  const [buyOrders, setBuyOrders] = useState([]); // 매수 데이터
+  const [sellOrders, setSellOrders] = useState([]); // 매도 데이터
+
+  // 호가 데이터 가져오기 - propertyId 변경 시 다시 로드
+  useEffect(() => {
+    const fetchOrderBook = async () => {
+      try {
+        const response = await axios.get(`/api/orders/${propertyId}`);
+        const { buy, sell } = response.data.order_book;
+        // 데이터를 가격 내림차순 정렬
+        setBuyOrders(
+          Object.entries(buy).flatMap(([price, orders]) =>
+            orders.map((order) => ({
+              price: parseFloat(price),
+              quantity: order.quantity,
+            }))
+          )
+        );
+        setSellOrders(
+          Object.entries(sell).flatMap(([price, orders]) =>
+            orders.map((order) => ({
+              price: parseFloat(price),
+              quantity: order.quantity,
+            }))
+          )
+        );
+      } catch (err) {
+        console.error('호가 데이터 가져오기 실패:', err);
+      }
+    };
+
+    fetchOrderBook();
+  }, [propertyId]);
 
   return (
     <div className="border rounded p-3 bg-white">
@@ -15,11 +51,13 @@ export default function TradeBoard() {
         className="mb-3"
       >
         <Tab eventKey="buy" title="매수">
-          <TradeOptionsBox type="buy" />
+          {/* 매수 데이터 전달 */}
+          <TradeOptionsBox type="buy" trades={buyOrders} />
           <TradeOrderForm type="buy" />
         </Tab>
         <Tab eventKey="sell" title="매도">
-          <TradeOptionsBox type="sell" />
+          {/* 매도 데이터 전달 */}
+          <TradeOptionsBox type="sell" trades={sellOrders} />
           <TradeOrderForm type="sell" />
         </Tab>
       </Tabs>

--- a/src/pages/property_detail/trade/TradeBoard.jsx
+++ b/src/pages/property_detail/trade/TradeBoard.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { Tab, Tabs } from 'react-bootstrap';
+import TradeOptionsBox from './TradeOptionsBox';
+import TradeOrderForm from './TradeOrderForm';
+
+export default function TradeBoard() {
+  const [key, setKey] = useState('buy');
+
+  return (
+    <div className="border rounded p-3 bg-white">
+      <Tabs
+        id="trade-tabs"
+        activeKey={key}
+        onSelect={(k) => setKey(k)}
+        className="mb-3"
+      >
+        <Tab eventKey="buy" title="매수">
+          <TradeOptionsBox type="buy" />
+          <TradeOrderForm type="buy" />
+        </Tab>
+        <Tab eventKey="sell" title="매도">
+          <TradeOptionsBox type="sell" />
+          <TradeOrderForm type="sell" />
+        </Tab>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/pages/property_detail/trade/TradeBoard.jsx
+++ b/src/pages/property_detail/trade/TradeBoard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Tab, Tabs } from 'react-bootstrap';
 import TradeOptionsBox from './TradeOptionsBox';
 import TradeOrderForm from './TradeOrderForm';
@@ -10,36 +10,79 @@ export default function TradeBoard() {
   const [key, setKey] = useState('buy'); // 현재 활성화된 탭
   const [buyOrders, setBuyOrders] = useState([]); // 매수 데이터
   const [sellOrders, setSellOrders] = useState([]); // 매도 데이터
+  const websocketRef = useRef(null); // WebSocket 참조
 
-  // 호가 데이터 가져오기 - propertyId 변경 시 다시 로드
+  // 호가 데이터를 정렬 함수
+  const sortOrderBook = (orderBook) => ({
+    buy: Object.entries(orderBook.buy || {}).flatMap(([price, orders]) =>
+      orders.map((order) => ({
+        price: parseFloat(price),
+        quantity: order.quantity,
+      }))
+    ),
+    sell: Object.entries(orderBook.sell || {}).flatMap(([price, orders]) =>
+      orders.map((order) => ({
+        price: parseFloat(price),
+        quantity: order.quantity,
+      }))
+    ),
+  });
+
+  // 초기 REST API를 통해 호가 데이터를 가져오기
   useEffect(() => {
     const fetchOrderBook = async () => {
       try {
         const response = await axios.get(`/api/orders/${propertyId}`);
-        const { buy, sell } = response.data.order_book;
-        // 데이터를 가격 내림차순 정렬
-        setBuyOrders(
-          Object.entries(buy).flatMap(([price, orders]) =>
-            orders.map((order) => ({
-              price: parseFloat(price),
-              quantity: order.quantity,
-            }))
-          )
-        );
-        setSellOrders(
-          Object.entries(sell).flatMap(([price, orders]) =>
-            orders.map((order) => ({
-              price: parseFloat(price),
-              quantity: order.quantity,
-            }))
-          )
-        );
+        const sortedOrders = sortOrderBook(response.data.order_book);
+        setBuyOrders(sortedOrders.buy);
+        setSellOrders(sortedOrders.sell);
+        console.log(`호가 데이터 가져오기 성공: ${propertyId}`);
       } catch (err) {
         console.error('호가 데이터 가져오기 실패:', err);
       }
     };
 
     fetchOrderBook();
+  }, [propertyId]);
+
+  // WebSocket 연결 관리
+  useEffect(() => {
+    if (websocketRef.current) {
+      websocketRef.current.close();
+    }
+
+    const ws = new WebSocket(`ws://localhost:8000/api/ws/orders/${propertyId}`);
+    websocketRef.current = ws;
+
+    ws.onopen = () => {
+      console.log(`WebSocket 연결 성공: propertyId=${propertyId}`);
+    };
+
+    ws.onmessage = (event) => {
+      console.log('WebSocket 메시지 수신:', event.data);
+      try {
+        const data = JSON.parse(event.data);
+        const sortedOrders = sortOrderBook(data.order_book);
+        console.log('업데이트된 매수 데이터:', sortedOrders.buy);
+        console.log('업데이트된 매도 데이터:', sortedOrders.sell);
+        setBuyOrders(sortedOrders.buy);
+        setSellOrders(sortedOrders.sell);
+      } catch (err) {
+        console.error('WebSocket 메시지 처리 실패:', err);
+      }
+    };
+
+    ws.onclose = () => {
+      console.warn('WebSocket 연결이 종료되었습니다.');
+    };
+
+    ws.onerror = (error) => {
+      console.error('WebSocket 오류:', error);
+    };
+
+    return () => {
+      ws.close();
+    };
   }, [propertyId]);
 
   return (

--- a/src/pages/property_detail/trade/TradeContext.jsx
+++ b/src/pages/property_detail/trade/TradeContext.jsx
@@ -1,0 +1,17 @@
+import React, { createContext, useContext } from 'react';
+
+export const TradeContext = createContext(null);
+
+export const useTradeContext = () => {
+  const context = useContext(TradeContext);
+  if (!context) {
+    throw new Error('TradeProvider가 없는 곳에 useTradeContext를 참조');
+  }
+  return context;
+};
+
+export const TradeProvider = ({ children, id }) => {
+  return (
+    <TradeContext.Provider value={{ id }}>{children}</TradeContext.Provider>
+  );
+};

--- a/src/pages/property_detail/trade/TradeGraph.jsx
+++ b/src/pages/property_detail/trade/TradeGraph.jsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Button } from 'react-bootstrap';
+
+export default function TradeGraph() {
+  const [activeTab, setActiveTab] = useState('1개월');
+
+  const data = [
+    { date: '10월 24일', price: 58000 },
+    { date: '10월 26일', price: 57000 },
+    { date: '10월 28일', price: 58500 },
+    { date: '10월 30일', price: 56000 },
+    { date: '11월 4일', price: 59000 },
+    { date: '11월 8일', price: 57500 },
+    { date: '11월 14일', price: 50500 },
+    { date: '11월 20일', price: 55500 },
+  ];
+
+  const timeFrames = ['1시간', '1일'];
+
+  return (
+    <div className="border rounded p-3 bg-white h-100">
+      <div className="d-flex justify-content-between mb-2">
+        <div className="d-flex gap-2">
+          {timeFrames.map((tab) => (
+            <Button
+              key={tab}
+              variant={activeTab === tab ? 'primary' : 'light'}
+              className={`rounded-pill px-3 py-1 ${
+                activeTab === tab ? 'text-white' : 'text-secondary'
+              }`}
+              onClick={() => setActiveTab(tab)}
+              style={{
+                backgroundColor: activeTab === tab ? '#8e44ad' : 'transparent',
+                border: 'none',
+                fontSize: '0.9rem',
+              }}
+            >
+              {tab}
+            </Button>
+          ))}
+        </div>
+        <span className="text-danger">-4.31%</span>
+      </div>
+
+      <div style={{ width: '100%', height: 400 }}>
+        <ResponsiveContainer>
+          <LineChart
+            data={data}
+            margin={{
+              top: 5,
+              right: 30,
+              left: 20,
+              bottom: 5,
+            }}
+          >
+            <defs>
+              <linearGradient id="colorPrice" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#8e44ad" stopOpacity={0.1} />
+                <stop offset="95%" stopColor="#8e44ad" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="date"
+              axisLine={false}
+              tickLine={false}
+              style={{ fontSize: '0.8rem' }}
+            />
+            <YAxis
+              domain={['dataMin - 1000', 'dataMax + 1000']}
+              axisLine={false}
+              tickLine={false}
+              style={{ fontSize: '0.8rem' }}
+              tickFormatter={(value) => `${value.toLocaleString()}`}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'white',
+                border: '1px solid #e0e0e0',
+                borderRadius: '4px',
+                padding: '8px',
+              }}
+              formatter={(value) => [`${value.toLocaleString()}원`]}
+              labelStyle={{ color: '#666' }}
+            />
+            <Line
+              type="monotone"
+              dataKey="price"
+              stroke="#8e44ad"
+              strokeWidth={2}
+              dot={{ r: 3, fill: '#8e44ad' }}
+              activeDot={{ r: 5 }}
+              fill="url(#colorPrice)"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/property_detail/trade/TradeMain.jsx
+++ b/src/pages/property_detail/trade/TradeMain.jsx
@@ -1,30 +1,36 @@
 import React from 'react';
-import { Container, Row, Col, Navbar, Form, Button } from 'react-bootstrap';
+import { Container, Row, Col, Navbar } from 'react-bootstrap';
+import { useParams } from 'react-router-dom';
+import { TradeProvider } from './TradeContext';
 import TradeGraph from './TradeGraph';
 import TradeBoard from './TradeBoard';
 import './trade_style.css';
 
 export default function TradeMain() {
-  return (
-    <div className="bg-light min-vh-100">
-      <Navbar bg="white" className="border-bottom mb-3">
-        <Container>
-          <Navbar.Brand href="#" className="d-flex align-items-center">
-            <div className="text-purple me-2">SOL집모아</div>
-          </Navbar.Brand>
-        </Container>
-      </Navbar>
+  const { id } = useParams(); // 건물id
 
-      <Container>
-        <Row>
-          <Col md={8}>
-            <TradeGraph />
-          </Col>
-          <Col md={4}>
-            <TradeBoard />
-          </Col>
-        </Row>
-      </Container>
-    </div>
+  return (
+    <TradeProvider id={id}>
+      <div className="bg-light min-vh-100">
+        <Navbar bg="white" className="border-bottom mb-3">
+          <Container>
+            <Navbar.Brand href="#" className="d-flex align-items-center">
+              <div className="text-purple me-2">SOL집모아</div>
+            </Navbar.Brand>
+          </Container>
+        </Navbar>
+
+        <Container>
+          <Row>
+            <Col md={8}>
+              <TradeGraph />
+            </Col>
+            <Col md={4}>
+              <TradeBoard />
+            </Col>
+          </Row>
+        </Container>
+      </div>
+    </TradeProvider>
   );
 }

--- a/src/pages/property_detail/trade/TradeMain.jsx
+++ b/src/pages/property_detail/trade/TradeMain.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Container, Row, Col, Navbar, Form, Button } from 'react-bootstrap';
+import TradeGraph from './TradeGraph';
+import TradeBoard from './TradeBoard';
+import './trade_style.css';
+
+export default function TradeMain() {
+  return (
+    <div className="bg-light min-vh-100">
+      <Navbar bg="white" className="border-bottom mb-3">
+        <Container>
+          <Navbar.Brand href="#" className="d-flex align-items-center">
+            <div className="text-purple me-2">SOL집모아</div>
+          </Navbar.Brand>
+        </Container>
+      </Navbar>
+
+      <Container>
+        <Row>
+          <Col md={8}>
+            <TradeGraph />
+          </Col>
+          <Col md={4}>
+            <TradeBoard />
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  );
+}

--- a/src/pages/property_detail/trade/TradeOptionsBox.jsx
+++ b/src/pages/property_detail/trade/TradeOptionsBox.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Table } from 'react-bootstrap';
+
+export default function TradeOptionsBox({ type }) {
+  const trades = [
+    { price: '53,500', quantity: 100, total: '5,350,000' },
+    { price: '53,000', quantity: 150, total: '7,950,000' },
+    { price: '52,500', quantity: 200, total: '10,500,000' },
+    { price: '52,000', quantity: 250, total: '13,000,000' },
+    { price: '51,500', quantity: 300, total: '15,450,000' },
+  ];
+
+  return (
+    <div className="mb-3">
+      <Table striped bordered hover size="sm">
+        <thead>
+          <tr className="bg-light">
+            <th>가격</th>
+            <th>수량</th>
+            <th>총액</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trades.map((trade, index) => (
+            <tr
+              key={index}
+              className={type === 'buy' ? 'text-danger' : 'text-primary'}
+            >
+              <td>{trade.price}</td>
+              <td>{trade.quantity}</td>
+              <td>{trade.total}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+}

--- a/src/pages/property_detail/trade/TradeOptionsBox.jsx
+++ b/src/pages/property_detail/trade/TradeOptionsBox.jsx
@@ -3,10 +3,10 @@ import { Table } from 'react-bootstrap';
 
 export default function TradeOptionsBox({ type, trades }) {
   return (
-    <div className="mb-3">
-      <Table striped bordered hover size="sm">
+    <div className="mb-3 p-3 border rounded shadow-sm bg-white">
+      <Table bordered hover size="sm" className="text-center custom-table">
         <thead>
-          <tr className="bg-light">
+          <tr className="bg-pastel-purple text-white">
             <th>가격</th>
             <th>수량</th>
             <th>총액</th>
@@ -17,16 +17,16 @@ export default function TradeOptionsBox({ type, trades }) {
             trades.map((trade, index) => (
               <tr
                 key={index}
-                className={type === 'buy' ? 'text-danger' : 'text-primary'}
+                className={type === 'buy' ? 'text-success' : 'text-danger'}
               >
-                <td>{trade.price}</td>
-                <td>{trade.quantity}</td>
+                <td>{trade.price.toLocaleString()}</td>
+                <td>{trade.quantity.toLocaleString()}</td>
                 <td>{(trade.price * trade.quantity).toLocaleString()}</td>
               </tr>
             ))
           ) : (
             <tr>
-              <td colSpan="3" className="text-center">
+              <td colSpan="3" className="text-center text-muted">
                 데이터가 없습니다.
               </td>
             </tr>

--- a/src/pages/property_detail/trade/TradeOptionsBox.jsx
+++ b/src/pages/property_detail/trade/TradeOptionsBox.jsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import { Table } from 'react-bootstrap';
 
-export default function TradeOptionsBox({ type }) {
-  const trades = [
-    { price: '53,500', quantity: 100, total: '5,350,000' },
-    { price: '53,000', quantity: 150, total: '7,950,000' },
-    { price: '52,500', quantity: 200, total: '10,500,000' },
-    { price: '52,000', quantity: 250, total: '13,000,000' },
-    { price: '51,500', quantity: 300, total: '15,450,000' },
-  ];
-
+export default function TradeOptionsBox({ type, trades }) {
   return (
     <div className="mb-3">
       <Table striped bordered hover size="sm">
@@ -21,16 +13,24 @@ export default function TradeOptionsBox({ type }) {
           </tr>
         </thead>
         <tbody>
-          {trades.map((trade, index) => (
-            <tr
-              key={index}
-              className={type === 'buy' ? 'text-danger' : 'text-primary'}
-            >
-              <td>{trade.price}</td>
-              <td>{trade.quantity}</td>
-              <td>{trade.total}</td>
+          {trades && trades.length > 0 ? (
+            trades.map((trade, index) => (
+              <tr
+                key={index}
+                className={type === 'buy' ? 'text-danger' : 'text-primary'}
+              >
+                <td>{trade.price}</td>
+                <td>{trade.quantity}</td>
+                <td>{(trade.price * trade.quantity).toLocaleString()}</td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td colSpan="3" className="text-center">
+                데이터가 없습니다.
+              </td>
             </tr>
-          ))}
+          )}
         </tbody>
       </Table>
     </div>

--- a/src/pages/property_detail/trade/TradeOrderForm.jsx
+++ b/src/pages/property_detail/trade/TradeOrderForm.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Form, Button } from 'react-bootstrap';
+
+export default function TradeOrderForm({ type }) {
+  const buttonColor = type === 'buy' ? 'danger' : 'primary';
+  const buttonText = type === 'buy' ? '매수하기' : '매도하기';
+
+  return (
+    <Form>
+      <Form.Group className="mb-3">
+        <Form.Label>주문가격</Form.Label>
+        <Form.Control type="number" placeholder="53500" />
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label>주문수량</Form.Label>
+        <Form.Control type="number" placeholder="0" />
+      </Form.Group>
+      <div className="d-flex justify-content-between mb-3">
+        <span>{type === 'buy' ? '원화잔액' : '토큰잔액'}</span>
+        <span>0 {type === 'buy' ? '원' : '개'}</span>
+      </div>
+      <div className="d-flex justify-content-between mb-3">
+        <span>이용가능</span>
+        <span>0 {type === 'buy' ? '원' : '개'}</span>
+      </div>
+      <Button variant={buttonColor} className="w-100">
+        {buttonText}
+      </Button>
+    </Form>
+  );
+}

--- a/src/pages/property_detail/trade/TradeOrderForm.jsx
+++ b/src/pages/property_detail/trade/TradeOrderForm.jsx
@@ -1,31 +1,102 @@
-import React from 'react';
-import { Form, Button } from 'react-bootstrap';
+import React, { useState } from 'react';
+import { Form, Button, Modal } from 'react-bootstrap';
+import axios from 'axios';
+import { useTradeContext } from './TradeContext';
 
 export default function TradeOrderForm({ type }) {
+  const { id: propertyId } = useTradeContext(); // 건물Id를 Context에서 가져옴
+  const [price, setPrice] = useState(''); // 주문 가격 상태
+  const [quantity, setQuantity] = useState(''); // 주문 수량 상태
+  const [showModal, setShowModal] = useState(false); // 모달 표시 상태
+  const [modalMessage, setModalMessage] = useState(''); // 모달에 표시할 메시지 상태
+
+  // 버튼 스타일 및 텍스트를 매수/매도에 따라 동적으로 설정
   const buttonColor = type === 'buy' ? 'danger' : 'primary';
   const buttonText = type === 'buy' ? '매수하기' : '매도하기';
 
+  // 모달 닫기 핸들러
+  const handleClose = () => setShowModal(false);
+
+  // 폼 제출 핸들러 (매수/매도 API 요청)
+  const handleSubmit = async (event) => {
+    event.preventDefault(); // 폼 기본 동작 방지
+
+    try {
+      // API 엔드포인트와 요청 데이터 설정
+      const endpoint = `/api/orders/${propertyId}/${type}`;
+      const payload = {
+        price_per_token: parseInt(price, 10),
+        quantity: parseInt(quantity, 10),
+      };
+
+      // 주문 API 요청
+      const response = await axios.post(endpoint, payload);
+
+      // 성공 시 모달에 메시지 표시
+      setModalMessage(response.data.message);
+      setShowModal(true);
+    } catch (err) {
+      // 실패 시 오류 메시지 모달에 표시
+      const errorMessage =
+        err.response?.data?.detail || '주문 처리 중 오류가 발생했습니다.';
+      setModalMessage(errorMessage);
+      setShowModal(true);
+    }
+  };
+
   return (
-    <Form>
-      <Form.Group className="mb-3">
-        <Form.Label>주문가격</Form.Label>
-        <Form.Control type="number" placeholder="53500" />
-      </Form.Group>
-      <Form.Group className="mb-3">
-        <Form.Label>주문수량</Form.Label>
-        <Form.Control type="number" placeholder="0" />
-      </Form.Group>
-      <div className="d-flex justify-content-between mb-3">
-        <span>{type === 'buy' ? '원화잔액' : '토큰잔액'}</span>
-        <span>0 {type === 'buy' ? '원' : '개'}</span>
-      </div>
-      <div className="d-flex justify-content-between mb-3">
-        <span>이용가능</span>
-        <span>0 {type === 'buy' ? '원' : '개'}</span>
-      </div>
-      <Button variant={buttonColor} className="w-100">
-        {buttonText}
-      </Button>
-    </Form>
+    <>
+      {/* 매수/매도 주문 입력 폼 */}
+      <Form onSubmit={handleSubmit}>
+        <Form.Group className="mb-3">
+          <Form.Label>주문가격</Form.Label>
+          {/* 주문 가격 입력 필드 */}
+          <Form.Control
+            type="number"
+            placeholder="53500"
+            value={price}
+            onChange={(e) => setPrice(e.target.value)}
+          />
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label>주문수량</Form.Label>
+          {/* 주문 수량 입력 필드 */}
+          <Form.Control
+            type="number"
+            placeholder="0"
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value)}
+          />
+        </Form.Group>
+        {/* 사용자 잔액 및 이용 가능량 표시 */}
+        <div className="d-flex justify-content-between mb-3">
+          <span>{type === 'buy' ? '원화잔액' : '토큰잔액'}</span>
+          <span>0 {type === 'buy' ? '원' : '개'}</span>
+        </div>
+        <div className="d-flex justify-content-between mb-3">
+          <span>이용가능</span>
+          <span>0 {type === 'buy' ? '원' : '개'}</span>
+        </div>
+        {/* 매수/매도 버튼 */}
+        <Button type="submit" variant={buttonColor} className="w-100">
+          {buttonText}
+        </Button>
+      </Form>
+
+      {/* 주문 결과 모달 */}
+      <Modal show={showModal} onHide={handleClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>
+            {type === 'buy' ? '매수 결과' : '매도 결과'}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{modalMessage}</Modal.Body> {/* 결과 메시지 표시 */}
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose}>
+            닫기
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
   );
 }

--- a/src/pages/property_detail/trade/trade_style.css
+++ b/src/pages/property_detail/trade/trade_style.css
@@ -1,0 +1,32 @@
+:root {
+  --purple: #8e44ad;
+  --light-purple: #9b59b6;
+}
+
+.bg-purple {
+  background-color: var(--purple) !important;
+}
+
+.text-purple {
+  color: var(--purple) !important;
+}
+
+.btn-purple {
+  background-color: var(--purple) !important;
+  border-color: var(--purple) !important;
+  color: white !important;
+}
+
+.btn-purple:hover {
+  background-color: var(--light-purple) !important;
+  border-color: var(--light-purple) !important;
+}
+
+.nav-tabs .nav-link.active {
+  color: var(--purple) !important;
+  border-color: var(--purple) !important;
+}
+
+.nav-tabs .nav-link:hover {
+  border-color: var(--light-purple) !important;
+}

--- a/src/pages/property_detail/trade/trade_style.css
+++ b/src/pages/property_detail/trade/trade_style.css
@@ -30,3 +30,30 @@
 .nav-tabs .nav-link:hover {
   border-color: var(--light-purple) !important;
 }
+
+/* 호가창 표 스타일 */
+.custom-table {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.custom-table thead th {
+  background-color: #c695ee;
+  color: white;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.custom-table tbody tr {
+  background-color: white;
+}
+
+.custom-table tbody tr:hover {
+  background-color: #f3e5f5;
+}
+
+.custom-table td,
+.custom-table th {
+  border-color: #c695ee;
+}
+/* 호가창 표 스타일 */

--- a/src/routers/AppRouter.jsx
+++ b/src/routers/AppRouter.jsx
@@ -18,7 +18,7 @@ const AppRouter = createBrowserRouter([
     element: <MainPage />,
   },
   {
-    path: '/property/trade',
+    path: '/property/:id/trade',
     element: <TradeMain />,
   },
 ]);

--- a/src/routers/AppRouter.jsx
+++ b/src/routers/AppRouter.jsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import MainPage from '../pages/main/MainPage';
 import Signup from '../pages/home/Signup';
 import Login from '../pages/home/Login';
+import TradeMain from '../pages/property_detail/trade/TradeMain';
 
 const AppRouter = createBrowserRouter([
   {
@@ -15,6 +16,10 @@ const AppRouter = createBrowserRouter([
   {
     path: '/main/',
     element: <MainPage />,
+  },
+  {
+    path: '/property/trade',
+    element: <TradeMain />,
   },
 ]);
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8000',
         changeOrigin: true,
+        ws: true,
       },
     },
   },


### PR DESCRIPTION
## 개요

매수/매도 주문 화면, 호가창 UI를 구현 
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/9643b724-0136-4894-822c-a74022f427c8">


## 작업사항

#4 

## 변경로직

- **매수/매도 주문 API 연동**
  - 매수 주문: `/api/orders/{property_id}/buy` 엔드포인트와 연동
  - 매도 주문: `/api/orders/{property_id}/sell` 엔드포인트와 연동
  - 사용자가 입력한 데이터를 기반으로 API 요청 전달
  - 주문 결과 모달창 구현
 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/bfa5f47b-8b7a-48c6-9d66-bb75a0daa476">

- **호가창 화면 구현**
  - `/api/orders/{property_id}` 엔드포인트와 연동
  - 호가창 디자인 개선
<img width="393" alt="image" src="https://github.com/user-attachments/assets/bc6cfe0c-a199-481e-8286-e6bc64193a18">


