### PR TITLE
사용자 주문 화면 데이터 프론트엔드 렌더링 구현

### DIFF
--- a/src/pages/property_detail/trade/TradeBoard.jsx
+++ b/src/pages/property_detail/trade/TradeBoard.jsx
@@ -13,20 +13,27 @@ export default function TradeBoard() {
   const websocketRef = useRef(null); // WebSocket 참조
 
   // 호가 데이터를 정렬 함수
-  const sortOrderBook = (orderBook) => ({
-    buy: Object.entries(orderBook.buy || {}).flatMap(([price, orders]) =>
-      orders.map((order) => ({
-        price: parseFloat(price),
-        quantity: order.quantity,
-      }))
-    ),
-    sell: Object.entries(orderBook.sell || {}).flatMap(([price, orders]) =>
-      orders.map((order) => ({
-        price: parseFloat(price),
-        quantity: order.quantity,
-      }))
-    ),
-  });
+  const sortOrderBook = (orderBook) => {
+    const buyOrders = Object.entries(orderBook.buy || {})
+      .flatMap(([price, orders]) =>
+        orders.map((order) => ({
+          price: parseFloat(price),
+          quantity: order.quantity,
+        }))
+      )
+      .sort((a, b) => b.price - a.price); // 매수는 높은 가격 순으로 정렬
+
+    const sellOrders = Object.entries(orderBook.sell || {})
+      .flatMap(([price, orders]) =>
+        orders.map((order) => ({
+          price: parseFloat(price),
+          quantity: order.quantity,
+        }))
+      )
+      .sort((a, b) => a.price - b.price); // 매도는 낮은 가격 순으로 정렬
+
+    return { buy: buyOrders, sell: sellOrders };
+  };
 
   // 초기 REST API를 통해 호가 데이터를 가져오기
   useEffect(() => {
@@ -51,7 +58,7 @@ export default function TradeBoard() {
       websocketRef.current.close();
     }
 
-    const ws = new WebSocket(`ws://localhost:8000/api/ws/orders/${propertyId}`);
+    const ws = new WebSocket(`/api/ws/orders/${propertyId}`);
     websocketRef.current = ws;
 
     ws.onopen = () => {

--- a/src/pages/property_detail/trade/TradeMain.jsx
+++ b/src/pages/property_detail/trade/TradeMain.jsx
@@ -5,6 +5,7 @@ import { TradeProvider } from './TradeContext';
 import TradeGraph from './TradeGraph';
 import TradeBoard from './TradeBoard';
 import './trade_style.css';
+import Header from '../../../components/header/Header';
 
 export default function TradeMain() {
   const { id } = useParams(); // 건물id
@@ -12,13 +13,7 @@ export default function TradeMain() {
   return (
     <TradeProvider id={id}>
       <div className="bg-light min-vh-100">
-        <Navbar bg="white" className="border-bottom mb-3">
-          <Container>
-            <Navbar.Brand href="#" className="d-flex align-items-center">
-              <div className="text-purple me-2">SOL집모아</div>
-            </Navbar.Brand>
-          </Container>
-        </Navbar>
+        <Header></Header>
 
         <Container>
           <Row>

--- a/src/pages/property_detail/trade/TradeOptionsBox.jsx
+++ b/src/pages/property_detail/trade/TradeOptionsBox.jsx
@@ -1,7 +1,28 @@
 import React from 'react';
 import { Table } from 'react-bootstrap';
 
+// 데이터 그룹화 함수
+const groupTradesByPrice = (trades) => {
+  const grouped = {};
+  trades.forEach((trade) => {
+    if (grouped[trade.price]) {
+      grouped[trade.price].quantity += trade.quantity;
+    } else {
+      grouped[trade.price] = { price: trade.price, quantity: trade.quantity };
+    }
+  });
+  return Object.values(grouped);
+};
+
 export default function TradeOptionsBox({ type, trades }) {
+  // 가격별로 그룹화된 데이터 생성
+  const groupedTrades = groupTradesByPrice(trades);
+
+  // 타입에 따라 정렬 (매수: 내림차순, 매도: 오름차순)
+  const sortedTrades = groupedTrades.sort((a, b) =>
+    type === 'buy' ? b.price - a.price : a.price - b.price
+  );
+
   return (
     <div className="mb-3 p-3 border rounded shadow-sm bg-white">
       <Table bordered hover size="sm" className="text-center custom-table">
@@ -13,8 +34,8 @@ export default function TradeOptionsBox({ type, trades }) {
           </tr>
         </thead>
         <tbody>
-          {trades && trades.length > 0 ? (
-            trades.map((trade, index) => (
+          {sortedTrades && sortedTrades.length > 0 ? (
+            sortedTrades.map((trade, index) => (
               <tr
                 key={index}
                 className={type === 'buy' ? 'text-success' : 'text-danger'}


### PR DESCRIPTION
## 개요

사용자의 매수 및 매도 주문 화면에서 필요한 데이터를 제공하는 API를 구현하여 주문 가능 금액과 거래 가능 토큰 개수를 표시하는 기능을 추가

## 작업사항

#21 

## 변경로직

<img width="442" alt="image" src="https://github.com/user-attachments/assets/24afdfaf-e88f-4794-bf71-a4fcb6a9d0a3">

- **매수 주문 화면**: 
  - `/api/users/{user_id}/buy-order-balance` 엔드포인트를 통해 사용자의 `total_balance`(보유 금액) , `orderable_balance`(주문 가능 금액)를 조회하는 API 구현.
  - 프론트엔드에서 해당 API를 호출해 매수 주문 화면에 주문 가능 금액 표시.

<img width="422" alt="image" src="https://github.com/user-attachments/assets/1edd30d5-bfa3-4788-97a6-dfd4ad6f6e72">

- **매도 주문 화면**: 
  - `/api/users/{user_id}/sell-order-balance/{property_id}` 엔드포인트를 통해 특정 건물에 대한 `quantity`(보유 수량),  `tradeable_tokens`(거래 가능 토큰)를 조회하는 API 구현.
  - 프론트엔드에서 해당 API를 호출해 매도 주문 화면에 거래 가능 토큰 개수 표시.