### PR TITLE
건물 단일가매매 기록 프론트엔드 렌더링 구현

### DIFF
--- a/src/pages/property_detail/trade/TradeGraph.jsx
+++ b/src/pages/property_detail/trade/TradeGraph.jsx
@@ -1,109 +1,187 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   LineChart,
   Line,
+  BarChart,
+  Bar,
   XAxis,
   YAxis,
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { Button } from 'react-bootstrap';
+import axios from 'axios';
+import { useTradeContext } from './TradeContext';
 
 export default function TradeGraph() {
-  const [activeTab, setActiveTab] = useState('1개월');
+  const { id: propertyId } = useTradeContext(); // Context에서 건물 ID 가져오기
+  const [data, setData] = useState([]); // 데이터를 저장할 상태
 
-  const data = [
-    { date: '10월 24일', price: 58000 },
-    { date: '10월 26일', price: 57000 },
-    { date: '10월 28일', price: 58500 },
-    { date: '10월 30일', price: 56000 },
-    { date: '11월 4일', price: 59000 },
-    { date: '11월 8일', price: 57500 },
-    { date: '11월 14일', price: 50500 },
-    { date: '11월 20일', price: 55500 },
-  ];
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          `/api/properties/${propertyId}/history`
+        );
+        const history = response.data.history;
 
-  const timeFrames = ['1시간', '1일'];
+        // 날짜를 기준으로 데이터를 정렬
+        const sortedHistory = history.sort(
+          (a, b) => new Date(a.recorded_date) - new Date(b.recorded_date)
+        );
+
+        // 필요한 필드만 포함한 데이터로 변환
+        const combinedData = sortedHistory.map((item) => ({
+          date: item.recorded_date,
+          time: new Date(item.recorded_date).toLocaleTimeString('ko-KR', {
+            hour: '2-digit',
+            minute: '2-digit',
+          }), // 시간 정보만 추출
+          price: item.price,
+          volume: item.quantity,
+        }));
+
+        setData(combinedData); // 정제된 데이터를 상태에 저장
+      } catch (err) {
+        console.error(
+          '데이터 가져오기 실패:',
+          err.response?.data?.detail || err.message
+        );
+      }
+    };
+
+    fetchData(); // 데이터 요청 함수 실행
+  }, [propertyId]);
 
   return (
     <div className="border rounded p-3 bg-white h-100">
-      <div className="d-flex justify-content-between mb-2">
-        <div className="d-flex gap-2">
-          {timeFrames.map((tab) => (
-            <Button
-              key={tab}
-              variant={activeTab === tab ? 'primary' : 'light'}
-              className={`rounded-pill px-3 py-1 ${
-                activeTab === tab ? 'text-white' : 'text-secondary'
-              }`}
-              onClick={() => setActiveTab(tab)}
-              style={{
-                backgroundColor: activeTab === tab ? '#8e44ad' : 'transparent',
-                border: 'none',
-                fontSize: '0.9rem',
-              }}
-            >
-              {tab}
-            </Button>
-          ))}
-        </div>
-        <span className="text-danger">-4.31%</span>
-      </div>
-
-      <div style={{ width: '100%', height: 400 }}>
-        <ResponsiveContainer>
-          <LineChart
-            data={data}
-            margin={{
-              top: 5,
-              right: 30,
-              left: 20,
-              bottom: 5,
+      {/* 가격을 표시하는 라인 차트 */}
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart
+          data={data}
+          syncId="chart" // 아래 바 차트와 X축 동기화
+          margin={{ top: 5, right: 30, left: 20, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />{' '}
+          {/* 격자선 */}
+          <XAxis
+            dataKey="time"
+            axisLine={false}
+            tickLine={false}
+            tick={false} // X축 숨기기
+            label={false}
+          />
+          <YAxis
+            yAxisId="left"
+            domain={['dataMin - 1000', 'dataMax + 1000']} // Y축 범위 설정
+            axisLine={false}
+            tickLine={false}
+            style={{ fontSize: '0.8rem' }}
+            tickFormatter={(value) => `${value.toLocaleString()}`} // 숫자 형식 지정
+          />
+          <Tooltip
+            content={({ active, payload }) => {
+              if (active && payload && payload.length) {
+                const { date, price, volume } = payload[0].payload;
+                return (
+                  <div
+                    style={{
+                      backgroundColor: 'white',
+                      border: '1px solid #ddd',
+                      borderRadius: '5px',
+                      padding: '10px',
+                    }}
+                  >
+                    {/* 툴팁에 날짜, 시간, 가격, 거래량 표시 */}
+                    <p style={{ margin: 0 }}>
+                      날짜: {new Date(date).toLocaleDateString('ko-KR')}
+                    </p>
+                    <p style={{ margin: 0 }}>
+                      시간: {new Date(date).toLocaleTimeString('ko-KR')}
+                    </p>
+                    <p style={{ margin: 0 }}>
+                      가격: {price.toLocaleString()}원
+                    </p>
+                    <p style={{ margin: 0 }}>
+                      거래량: {volume.toLocaleString()}개
+                    </p>
+                  </div>
+                );
+              }
+              return null; // 툴팁 숨김
             }}
-          >
-            <defs>
-              <linearGradient id="colorPrice" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#8e44ad" stopOpacity={0.1} />
-                <stop offset="95%" stopColor="#8e44ad" stopOpacity={0} />
-              </linearGradient>
-            </defs>
-            <CartesianGrid strokeDasharray="3 3" vertical={false} />
-            <XAxis
-              dataKey="date"
-              axisLine={false}
-              tickLine={false}
-              style={{ fontSize: '0.8rem' }}
-            />
-            <YAxis
-              domain={['dataMin - 1000', 'dataMax + 1000']}
-              axisLine={false}
-              tickLine={false}
-              style={{ fontSize: '0.8rem' }}
-              tickFormatter={(value) => `${value.toLocaleString()}`}
-            />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: 'white',
-                border: '1px solid #e0e0e0',
-                borderRadius: '4px',
-                padding: '8px',
-              }}
-              formatter={(value) => [`${value.toLocaleString()}원`]}
-              labelStyle={{ color: '#666' }}
-            />
-            <Line
-              type="monotone"
-              dataKey="price"
-              stroke="#8e44ad"
-              strokeWidth={2}
-              dot={{ r: 3, fill: '#8e44ad' }}
-              activeDot={{ r: 5 }}
-              fill="url(#colorPrice)"
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+          />
+          <Line
+            yAxisId="left"
+            type="linear" // 선을 직선으로 설정
+            dataKey="price"
+            name="가격"
+            stroke="#DF0101" // 선 색상(빨간색)
+            strokeWidth={2}
+            dot={false} // 데이터 점 제거
+            activeDot={false} // 활성 데이터 점 제거
+          />
+        </LineChart>
+      </ResponsiveContainer>
+
+      {/* 차트 사이 구분선 */}
+      <div
+        style={{
+          borderTop: '1px solid #ddd',
+          margin: '0 20px',
+          width: 'calc(100% - 40px)',
+        }}
+      ></div>
+
+      {/* 거래량을 표시하는 바 차트 */}
+      <ResponsiveContainer width="100%" height={150}>
+        <BarChart
+          data={data}
+          syncId="chart" // 위 라인 차트와 X축 동기화
+          margin={{ top: 0, right: 30, left: 20, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="time"
+            axisLine={false}
+            tickLine={false}
+            style={{ fontSize: '0.8rem' }}
+          />
+          <YAxis
+            axisLine={false}
+            tickLine={false}
+            style={{ fontSize: '0.8rem' }}
+            tickFormatter={(value) => `${value.toLocaleString()}개`} // 거래량 형식 지정
+          />
+          <Tooltip
+            content={({ active, payload }) => {
+              if (active && payload && payload.length) {
+                const { date, volume } = payload[0].payload;
+                return (
+                  <div
+                    style={{
+                      backgroundColor: 'white',
+                      border: '1px solid #ddd',
+                      borderRadius: '5px',
+                      padding: '10px',
+                    }}
+                  >
+                    {/* 툴팁에 시간과 거래량 표시 */}
+                    <p style={{ margin: 0 }}>
+                      시간: {new Date(date).toLocaleTimeString('ko-KR')}
+                    </p>
+                    <p style={{ margin: 0 }}>
+                      거래량: {volume.toLocaleString()}개
+                    </p>
+                  </div>
+                );
+              }
+              return null;
+            }}
+          />
+          <Bar dataKey="volume" name="거래량" fill="#5F04B4" barSize={20} />
+        </BarChart>
+      </ResponsiveContainer>
     </div>
   );
 }


### PR DESCRIPTION
## 개요

-  건물 단일가매매 기록 프론트엔드 렌더링 구현

## 작업사항

#22

## 변경로직

<img width="734" alt="image" src="https://github.com/user-attachments/assets/45159867-8741-46a4-9592-c385b3005394">

- **데이터 호출 및 렌더링**:
  - `/api/properties/{property_id}/history` API 호출.
  - 건물의 단일가매매 기록(날짜별 가격, 체결 수량)을 차트 형태로 화면에 표시.
  - 최신 날짜 기준 최대 100개의 데이터를 조회하여 렌더링.

