### PR TITLE
마이페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-bootstrap": "^2.10.5",
     "react-bootstrap-icons": "^1.11.4",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-router-dom": "^6.28.0",
     "recharts": "^2.13.3",
     "socket.io-client": "^4.8.1"

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -25,6 +25,8 @@ const Header = ({
     setPlaceholder(result.name); // Placeholder 업데이트
   };
 
+  const navigate = useNavigate();
+
   return (
     <Navbar bg="white" expand="lg" className="border-bottom">
       <Container className={`d-flex flex-wrap ${custom_header.container}`}>
@@ -105,7 +107,14 @@ const Header = ({
               alt="마이페이지 아이콘"
               style={{ width: '30px', height: '28px' }}
             />
-            <span className="ms-2">마이페이지</span>
+            <span
+              className="ms-2"
+              onClick={() => {
+                navigate('/mypage');
+              }}
+            >
+              마이페이지
+            </span>
           </Button>
           <Button
             onClick={() => {

--- a/src/pages/mypage/MyAsset.jsx
+++ b/src/pages/mypage/MyAsset.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Card, ListGroup } from 'react-bootstrap';
+import { useOwnershipContext } from './OwnershipContext';
+
+export default function MyAsset() {
+  const { balance } = useOwnershipContext();
+
+  return (
+    <Card className="shadow-sm bg-light border-light">
+      <Card.Body>
+        <Card.Title className="text-primary">내 보유자산</Card.Title>
+        <ListGroup variant="flush">
+          <ListGroup.Item className="d-flex justify-content-between">
+            <span>보유 KRW</span>
+            <span className="text-primary">
+              {balance?.total_balance?.toLocaleString() || 0} KRW
+            </span>
+          </ListGroup.Item>
+          <ListGroup.Item className="d-flex justify-content-between">
+            <span>총 매수</span>
+            <span className="text-primary">
+              {balance?.total_buy?.toLocaleString() || 0} KRW
+            </span>
+          </ListGroup.Item>
+          <ListGroup.Item className="d-flex justify-content-between">
+            <span>총 평가</span>
+            <span className="text-primary">
+              {balance?.total_eval?.toLocaleString() || 0} KRW
+            </span>
+          </ListGroup.Item>
+          <ListGroup.Item className="d-flex justify-content-between">
+            <span>총 평가손익</span>
+            <span className="text-primary">
+              {balance?.profit_loss?.toLocaleString() || 0} KRW
+            </span>
+          </ListGroup.Item>
+          <ListGroup.Item className="d-flex justify-content-between">
+            <span>수익률</span>
+            <span className="text-primary">{balance?.profit_rate || 0}%</span>
+          </ListGroup.Item>
+        </ListGroup>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/pages/mypage/MyHoldings.jsx
+++ b/src/pages/mypage/MyHoldings.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { Card, Row, Col, Container } from 'react-bootstrap';
+import { useOwnershipContext } from './OwnershipContext';
+
+export default function MyHoldings() {
+  const { ownerships } = useOwnershipContext();
+
+  return (
+    <Card className="shadow-sm bg-light border-light">
+      <Card.Body>
+        <Card.Title className="text-primary">보유 종목</Card.Title>
+        <Container fluid>
+          {ownerships.length > 0 ? (
+            <Row>
+              {ownerships.map((token, index) => {
+                const latestPrice = token.latest_price || 0;
+                const evalValue = token.quantity * latestPrice;
+                const buyValue = token.quantity * (token.buy_price || 0);
+                const profitLoss = evalValue - buyValue;
+                const profitRate =
+                  buyValue > 0 ? ((profitLoss / buyValue) * 100).toFixed(2) : 0;
+                const isProfitable = profitLoss > 0;
+
+                return (
+                  // 각 카드가 한 줄에 3개씩 배치되도록 설정
+                  <Col key={index} lg={4} md={6} sm={12} className="mb-4">
+                    <Card className="h-100 border-0 shadow-sm">
+                      <Card.Body>
+                        <div className="d-flex justify-content-between align-items-center mb-4">
+                          {/* 건물 이름과 층수 표시 */}
+                          <h3 className="m-0 fw-semibold">
+                            {token.building_name} - {token.detail_floor}층
+                          </h3>
+                          <span
+                            className={`fs-5 fw-semibold ${
+                              isProfitable ? 'text-success' : 'text-danger'
+                            }`}
+                          >
+                            {profitRate}%
+                          </span>
+                        </div>
+
+                        <Row className="g-4">
+                          <Col xs={6}>
+                            <div className="text-muted mb-2">보유수량</div>
+                            <div className="fs-5">
+                              {token.quantity.toLocaleString()}
+                            </div>
+                          </Col>
+
+                          <Col xs={6}>
+                            <div className="text-muted mb-2">현재 금액</div>
+                            <div className="fs-5">
+                              {latestPrice.toLocaleString()} KRW
+                            </div>
+                          </Col>
+
+                          <Col xs={6}>
+                            <div className="text-muted mb-2">평가금액</div>
+                            <div className="fs-5">
+                              {evalValue.toLocaleString()} KRW
+                            </div>
+                          </Col>
+
+                          <Col xs={6}>
+                            <div className="text-muted mb-2">매수평균가</div>
+                            <div className="fs-5">
+                              {token.buy_price?.toLocaleString() || '-'} KRW
+                            </div>
+                          </Col>
+                        </Row>
+
+                        <div className="mt-4 pt-3 border-top">
+                          <div className="text-muted mb-2">평가손익</div>
+                          <div
+                            className={`fs-4 fw-bold ${
+                              isProfitable ? 'text-success' : 'text-danger'
+                            }`}
+                          >
+                            {profitLoss !== 0
+                              ? `${profitLoss.toLocaleString()} KRW`
+                              : '-'}
+                          </div>
+                        </div>
+                      </Card.Body>
+                    </Card>
+                  </Col>
+                );
+              })}
+            </Row>
+          ) : (
+            <Card className="text-center p-5 border-0">
+              <Card.Body>
+                <h3 className="text-muted">보유 자산이 없습니다.</h3>
+              </Card.Body>
+            </Card>
+          )}
+        </Container>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/pages/mypage/MyPage.css
+++ b/src/pages/mypage/MyPage.css
@@ -1,0 +1,29 @@
+.my-page .nav-tabs-custom .nav-link {
+  color: #6c63ff;
+  border: none;
+  background-color: #f3f0ff;
+  margin-right: 5px;
+  border-radius: 5px;
+  transition: all 0.3s ease;
+}
+
+.my-page .nav-tabs-custom .nav-link.active {
+  background-color: #6c63ff !important;
+  color: white !important;
+  font-weight: bold;
+  border-radius: 5px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.card-custom {
+  background-color: #f8f9fa;
+  border: 1px solid #6c63ff;
+}
+
+.card-custom .text-primary {
+  color: #6c63ff !important;
+}
+
+.bg-light {
+  background-color: #f9f9fb !important;
+}

--- a/src/pages/mypage/MyPage.jsx
+++ b/src/pages/mypage/MyPage.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Container, Row, Col, Card, Nav } from 'react-bootstrap';
+import Portfolio from './Portfolio';
+import MyHoldings from './MyHoldings';
+import OrderHistory from './OrderHistory';
+import PendingOrders from './PendingOrders';
+import MyAsset from './MyAsset';
+import Header from '../../components/header/Header';
+import { OwnershipProvider } from './OwnershipContext';
+import './MyPage.css';
+
+export default function MyPage() {
+  const [activeTab, setActiveTab] = useState('보유자산');
+
+  return (
+    <OwnershipProvider>
+      <div className="my-page bg-light min-vh-100">
+        <Header />
+        <Container className="py-4">
+          <Nav
+            variant="tabs"
+            className="mb-4 nav-tabs-custom"
+            activeKey={activeTab}
+            onSelect={(selectedKey) => setActiveTab(selectedKey)}
+          >
+            <Nav.Item>
+              <Nav.Link eventKey="보유자산" className="custom-tab">
+                보유자산
+              </Nav.Link>
+            </Nav.Item>
+            <Nav.Item>
+              <Nav.Link eventKey="거래내역" className="custom-tab">
+                거래내역
+              </Nav.Link>
+            </Nav.Item>
+            <Nav.Item>
+              <Nav.Link eventKey="미체결" className="custom-tab">
+                미체결
+              </Nav.Link>
+            </Nav.Item>
+          </Nav>
+          <Card className="shadow-sm card-custom">
+            <Card.Body>
+              {activeTab === '보유자산' && (
+                <>
+                  <Row>
+                    <Col md={6}>
+                      <Portfolio />
+                    </Col>
+                    <Col md={6}>
+                      <MyAsset />
+                    </Col>
+                  </Row>
+                  <Row className="mt-4">
+                    <Col>
+                      <MyHoldings />
+                    </Col>
+                  </Row>
+                </>
+              )}
+              {activeTab === '거래내역' && <OrderHistory />}
+              {activeTab === '미체결' && <PendingOrders />}
+            </Card.Body>
+          </Card>
+        </Container>
+      </div>
+    </OwnershipProvider>
+  );
+}

--- a/src/pages/mypage/OrderHistory.jsx
+++ b/src/pages/mypage/OrderHistory.jsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Card, Table, Nav, Badge } from 'react-bootstrap';
+
+export default function OrderHistory() {
+  const [orders, setOrders] = useState([]);
+  const [filter, setFilter] = useState('fulfilled'); // 기본값은 "체결"
+
+  useEffect(() => {
+    const fetchOrders = async () => {
+      try {
+        const response = await axios.get('/api/order_archives', {
+          params: { status: filter }, // "체결" 또는 "취소"로 필터링
+          withCredentials: true,
+        });
+        setOrders(response.data.orders);
+      } catch (error) {
+        console.error('Error fetching orders:', error);
+      }
+    };
+
+    fetchOrders();
+  }, [filter]);
+
+  // 주문 유형 뱃지
+  const getOrderTypeBadge = (orderType) => {
+    switch (orderType) {
+      case 'buy':
+        return <Badge bg="danger">매수</Badge>; // 빨간색
+      case 'sell':
+        return <Badge bg="primary">매도</Badge>; // 파란색
+      default:
+        return <Badge bg="secondary">알 수 없음</Badge>;
+    }
+  };
+
+  // 주문 상태 뱃지
+  const getStatusBadge = (status) => {
+    switch (status) {
+      case 'fulfilled':
+        return <Badge bg="success">체결</Badge>; // 초록색
+      case 'cancelled':
+        return <Badge bg="secondary">취소</Badge>; // 회색
+      default:
+        return <Badge bg="secondary">알 수 없음</Badge>;
+    }
+  };
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Body>
+        {/* 필터링 네비게이션 */}
+        <Nav
+          variant="tabs"
+          className="mb-3"
+          activeKey={filter}
+          onSelect={(selectedKey) => setFilter(selectedKey)}
+        >
+          <Nav.Item>
+            <Nav.Link eventKey="fulfilled">체결</Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link eventKey="cancelled">취소</Nav.Link>
+          </Nav.Item>
+        </Nav>
+
+        {/* 주문 기록 테이블 */}
+        <Table responsive>
+          <thead>
+            <tr>
+              <th>건물 - 층수</th>
+              <th>주문 유형</th>
+              <th>가격</th>
+              <th>수량</th>
+              <th>상태</th>
+              <th>날짜</th>
+            </tr>
+          </thead>
+          <tbody>
+            {orders.length > 0 ? (
+              orders.map((order, index) => (
+                <tr key={index}>
+                  {/* 건물 이름 - 층수 */}
+                  <td>
+                    {order.building_name} - {order.detail_floor}층
+                  </td>
+                  {/* 주문 유형 뱃지 */}
+                  <td>{getOrderTypeBadge(order.order_type)}</td>
+                  {/* 가격 */}
+                  <td>{order.price_per_token.toLocaleString()} KRW</td>
+                  {/* 수량 */}
+                  <td>{order.quantity}</td>
+                  {/* 상태 뱃지 */}
+                  <td>{getStatusBadge(order.status)}</td>
+                  {/* 날짜 */}
+                  <td>{new Date(order.created_at).toLocaleDateString()}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan="6" className="text-center">
+                  주문 기록이 없습니다.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/pages/mypage/OwnershipContext.jsx
+++ b/src/pages/mypage/OwnershipContext.jsx
@@ -1,0 +1,103 @@
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import axios from 'axios';
+
+// Context 생성
+const OwnershipContext = createContext();
+
+// Context Provider 컴포넌트
+export const OwnershipProvider = ({ children }) => {
+  const [ownerships, setOwnerships] = useState([]);
+  const [balance, setBalance] = useState(null);
+  const [colors, setColors] = useState([]);
+
+  // 랜덤 색상 생성 함수
+  const generateRandomColors = (count) => {
+    const predefinedColors = [
+      '#3498DB',
+      '#2ECC71',
+      '#9B59B6',
+      '#F1C40F',
+      '#E74C3C',
+      '#1ABC9C',
+      '#E67E22',
+      '#BDC3C7',
+      '#34495E',
+      '#7F8C8D',
+    ];
+    return Array.from(
+      { length: count },
+      (_, i) => predefinedColors[i % predefinedColors.length]
+    );
+  };
+
+  useEffect(() => {
+    const fetchOwnerships = async () => {
+      try {
+        const response = await axios.get('/api/ownerships', {
+          withCredentials: true,
+        });
+        const fetchedOwnerships = response.data.ownerships;
+
+        const ownershipsWithDetails = fetchedOwnerships.map((token) => ({
+          ...token,
+          detail_floor: token.detail_floor,
+          building_name: token.building_name,
+        }));
+
+        // 총 매수 금액 계산
+        const totalBuy = ownershipsWithDetails.reduce(
+          (sum, token) => sum + token.quantity * (token.buy_price || 0),
+          0
+        );
+
+        // 총 평가 금액 계산
+        const totalEval = ownershipsWithDetails.reduce(
+          (sum, token) => sum + token.quantity * (token.latest_price || 0),
+          0
+        );
+
+        // 총 평가 손익 계산
+        const profitLoss = totalEval - totalBuy;
+
+        // 수익률 계산
+        const profitRate =
+          totalBuy > 0 ? ((profitLoss / totalBuy) * 100).toFixed(2) : 0;
+
+        // 상태 업데이트
+        setOwnerships(ownershipsWithDetails);
+        setBalance((prev) => ({
+          ...prev,
+          total_buy: totalBuy,
+          total_eval: totalEval,
+          profit_loss: profitLoss,
+          profit_rate: profitRate,
+        }));
+        setColors(generateRandomColors(ownershipsWithDetails.length));
+      } catch (error) {
+        console.error('보유 종목 가져오기 오류', error);
+      }
+    };
+
+    const fetchBalance = async () => {
+      try {
+        const response = await axios.get('/api/users/buy-order-balance', {
+          withCredentials: true,
+        });
+        setBalance(response.data);
+      } catch (error) {
+        console.error('사용자 지갑 정보 가져오기 오류:', error);
+      }
+    };
+
+    fetchOwnerships();
+    fetchBalance();
+  }, []);
+
+  return (
+    <OwnershipContext.Provider value={{ ownerships, balance, colors }}>
+      {children}
+    </OwnershipContext.Provider>
+  );
+};
+
+export const useOwnershipContext = () => useContext(OwnershipContext);

--- a/src/pages/mypage/PendingOrders.jsx
+++ b/src/pages/mypage/PendingOrders.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react';
+import { Table, Card, Badge, Button } from 'react-bootstrap';
+import axios from 'axios';
+import { FiXCircle } from 'react-icons/fi';
+
+export default function PendingOrders() {
+  const [pendingOrders, setPendingOrders] = useState([]);
+
+  useEffect(() => {
+    const fetchPendingOrders = async () => {
+      try {
+        const response = await axios.get('/api/order_archives', {
+          params: { status: 'normal' }, // status를 normal로 필터링
+          withCredentials: true,
+        });
+        setPendingOrders(response.data.orders);
+      } catch (error) {
+        console.error('Error fetching pending orders:', error);
+      }
+    };
+
+    fetchPendingOrders();
+  }, []);
+
+  // 주문 유형 뱃지
+  const getOrderTypeBadge = (orderType) => {
+    switch (orderType) {
+      case 'buy':
+        return <Badge bg="danger">매수</Badge>; // 빨간색
+      case 'sell':
+        return <Badge bg="primary">매도</Badge>; // 파란색
+      default:
+        return <Badge bg="secondary">알 수 없음</Badge>;
+    }
+  };
+
+  // 상태 뱃지
+  const getStatusBadge = (status) => {
+    switch (status) {
+      case 'normal':
+        return <Badge bg="secondary">미체결</Badge>; // 회색
+      default:
+        return <Badge bg="secondary">알 수 없음</Badge>;
+    }
+  };
+
+  // 주문 취소 요청 함수
+  const cancelOrder = async (orderId) => {
+    try {
+      await axios.delete(`/api/orders/${orderId}`, { withCredentials: true });
+      // 주문 취소 성공 시 목록에서 제거
+      setPendingOrders((prevOrders) =>
+        prevOrders.filter((order) => order.id !== orderId)
+      );
+      alert('주문이 성공적으로 취소되었습니다.');
+    } catch (error) {
+      console.error('Error cancelling order:', error);
+      alert('주문 취소에 실패했습니다.');
+    }
+  };
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Body>
+        <Card.Title className="text-primary">미체결 주문</Card.Title>
+        <Table responsive>
+          <thead>
+            <tr>
+              <th>건물 - 층수</th>
+              <th>주문 유형</th>
+              <th>가격</th>
+              <th>수량</th>
+              <th>상태</th>
+              <th>주문 날짜</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {pendingOrders.length > 0 ? (
+              pendingOrders.map((order, index) => (
+                <tr key={index}>
+                  {/* 건물 이름 - 층수 */}
+                  <td>
+                    {order.building_name} - {order.detail_floor}층
+                  </td>
+                  {/* 주문 유형 뱃지 */}
+                  <td>{getOrderTypeBadge(order.order_type)}</td>
+                  {/* 가격 */}
+                  <td>{order.price_per_token.toLocaleString()} KRW</td>
+                  {/* 수량 */}
+                  <td>{order.quantity}</td>
+                  {/* 상태 뱃지 */}
+                  <td>{getStatusBadge(order.status)}</td>
+                  {/* 주문 날짜 */}
+                  <td>{new Date(order.created_at).toLocaleDateString()}</td>
+                  {/* 취소 버튼 */}
+                  <td>
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      onClick={() => cancelOrder(order.id)}
+                      className="d-flex align-items-center"
+                    >
+                      <FiXCircle style={{ marginRight: '4px' }} />
+                      취소
+                    </Button>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan="7" className="text-center">
+                  미체결된 주문이 없습니다.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/pages/mypage/Portfolio.jsx
+++ b/src/pages/mypage/Portfolio.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Card } from 'react-bootstrap';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+import { useOwnershipContext } from './OwnershipContext';
+
+export default function Portfolio() {
+  const { ownerships, colors } = useOwnershipContext();
+
+  // 파이차트 데이터 준비
+  const totalQuantity = ownerships.reduce(
+    (sum, item) => sum + item.quantity,
+    0
+  );
+
+  const pieData = ownerships.map((item) => ({
+    name: `${item.building_name} - ${item.detail_floor}층`,
+    value: item.quantity,
+    percentage: ((item.quantity / totalQuantity) * 100).toFixed(1),
+  }));
+
+  return (
+    <Card className="shadow-sm bg-light border-light">
+      <Card.Body>
+        <Card.Title className="text-primary">포트폴리오</Card.Title>
+        <Card className="shadow-sm bg-white border-light p-3">
+          <div
+            style={{
+              width: '100%',
+              height: 300,
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: '30px', // 차트와 텍스트 간격 조정
+            }}
+          >
+            <div style={{ flex: 1.5, height: '100%' }}>
+              {' '}
+              {/* 차트 영역 비율 */}
+              <ResponsiveContainer>
+                <PieChart>
+                  <Pie
+                    data={pieData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={60}
+                    outerRadius={80}
+                    dataKey="value"
+                  >
+                    {/* 랜덤 색상 적용 */}
+                    {pieData.map((entry, index) => (
+                      <Cell
+                        key={`cell-${index}`}
+                        fill={colors[index % colors.length]}
+                      />
+                    ))}
+                  </Pie>
+                  <Tooltip />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <div style={{ flex: 2 }}>
+              {' '}
+              {/* 텍스트 영역 비율 */}
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {pieData.map((item, index) => (
+                  <li
+                    key={index}
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      marginBottom: '10px',
+                    }}
+                  >
+                    <span style={{ display: 'flex', alignItems: 'center' }}>
+                      <span
+                        style={{
+                          width: '12px',
+                          height: '12px',
+                          backgroundColor: colors[index % colors.length],
+                          display: 'inline-block',
+                          borderRadius: '50%',
+                          marginRight: '10px',
+                        }}
+                      ></span>
+                      {item.name}
+                    </span>
+                    <span>{item.percentage}%</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </Card>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/routers/AppRouter.jsx
+++ b/src/routers/AppRouter.jsx
@@ -2,9 +2,10 @@ import { createBrowserRouter } from 'react-router-dom';
 import MainPage from '../pages/main/MainPage';
 import Signup from '../pages/home/Signup';
 import Login from '../pages/home/Login';
+import MyPage from '../pages/mypage/MyPage';
 import DetailIndex from '../pages/property_detail/info/DetailIndex';
 import TradeMain from '../pages/property_detail/trade/TradeMain';
-import FormIndex from '../pages/property_create/FormIndex'
+import FormIndex from '../pages/property_create/FormIndex';
 import RealEstatePage from '../pages/side_detail/RealEstatePage';
 
 const AppRouter = createBrowserRouter([
@@ -21,8 +22,12 @@ const AppRouter = createBrowserRouter([
     element: <MainPage />,
   },
   {
+    path: '/mypage',
+    element: <MyPage />,
+  },
+  {
     path: '/property_detail/info/:id',
-    element: <DetailIndex/>,
+    element: <DetailIndex />,
   },
   {
     path: '/property/:id/trade',


### PR DESCRIPTION
## 개요

- 마이페이지에서 사용자 보유 자산, 거래 내역, 미체결 주문 내역을 확인하고 관리할 수 있도록 구현

## 작업사항

#29 

## 변경로직
<img width="923" alt="image" src="https://github.com/user-attachments/assets/6df69bcf-70f6-470e-a7c5-9b0ac42f623d">

- **보유 자산 섹션 구현**
  - 포트폴리오: 파이차트로 사용자 보유 종목의 비율을 시각화.
  - 내 자산: 보유 자산, 평가 금액, 손익 등을 확인할 수 있는 UI 구현.
  - 보유 종목: 사용자가 소유한 종목의 상세 정보를 리스트로 확인 가능.

<img width="907" alt="image" src="https://github.com/user-attachments/assets/0dfe252a-fac6-42e0-83d3-b8e660eaec71">

- **거래 내역 섹션 구현**
  - 체결 내역: 사용자의 체결된 주문 기록을 표시.
  - 취소 내역: 취소된 주문 기록을 표시.

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/6a5e08d7-35ca-47ca-ad9b-84982f2f77af">

- **미체결 주문 내역 섹션 구현**
  - 미체결 주문 목록 확인 UI 구현.
  - 미체결 주문 취소 기능 추가.
